### PR TITLE
chore(ui): uncomment banner to display image upload limit update

### DIFF
--- a/components/Layouts/MainLayout.tsx
+++ b/components/Layouts/MainLayout.tsx
@@ -20,11 +20,11 @@ const MainLayout = ({ children }: MainLayoutProps) => {
 
   return (
     <div>
-      {/* <Banner
+      <Banner
         message={
-          '23 สิงหาคม 2568 | Propkub.com ประกาศ'
+          '[อัปเดต 16 กันยายน 2568] อัปโหลดรูปภาพต่อประกาศได้มากขึ้น จาก 8 รูปเป็น 10 รูป'
         }
-      /> */}
+      />
 
       <Header />
       <main className="min-h-screen py-4">{children}</main>


### PR DESCRIPTION
The banner was previously commented out during development and is now uncommented to inform users about the increased image upload limit from 8 to 10 images per listing. This change aligns with the recent feature update that allows users to upload more images.