### PR TITLE
chore: add Code Spell Checker to VS Code workspace recommendations (#20)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "streetsidesoftware.code-spell-checker",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "bradlc.vscode-tailwindcss"


### PR DESCRIPTION
This adds the "Code Spell Checker" extension (Street Side Software) to the workspace recommendations so contributors are prompted to install it when opening the repo in VS Code. This helps catch typos in code and docs.

Marketplace: streetsidesoftware.code-spell-checker. :contentReference[oaicite:4]{index=4}

Closes #20. :contentReference[oaicite:5]{index=5}